### PR TITLE
Update import statements for compatibility with Python 3.11-3.13

### DIFF
--- a/Jarvis/tool/Jarvis/machinery/imports.py
+++ b/Jarvis/tool/Jarvis/machinery/imports.py
@@ -22,7 +22,7 @@
 import sys
 import ast
 import os
-import importlib
+import importlib.abc
 import copy
 import pkg_resources
 import utils

--- a/Jarvis/tool/Jarvis/machinery/imports.py
+++ b/Jarvis/tool/Jarvis/machinery/imports.py
@@ -23,6 +23,7 @@ import sys
 import ast
 import os
 import importlib.abc
+import importlib.metadata
 import copy
 import pkg_resources
 import utils


### PR DESCRIPTION
## Why?

Per https://github.com/nuanced-dev/jarviscg/issues/2, https://github.com/nuanced-dev/jarviscg/issues/3 and https://github.com/nuanced-dev/jarviscg/issues/7, we can't run Jarvis with Python >3.10.16.

## How?

Update statements importing `importlib` functionality for compatibility with Python >=3.11.

Tested locally using Python versions 3.10.16, 3.11 and 3.12.7 and 3.13:

![Screenshot 2025-02-04 at 2 16 53 PM](https://github.com/user-attachments/assets/c81b142c-5d3b-4cc6-946a-7b87f3d0681f)

## Considerations

You will note in the screen shot above that Jarvis produces call graphs of slightly different sizes depending on the Python version.