### PR TITLE
Don't print filenames while processing

### DIFF
--- a/src/jarviscg/processing/base.py
+++ b/src/jarviscg/processing/base.py
@@ -27,7 +27,6 @@ class ProcessingBase(ast.NodeVisitor):
         self.modules_analyzed.add(self.modname)
 
         self.filename = os.path.abspath(filename)
-        print(filename)
         with open(filename, "rt",errors="ignore") as f:
             self.contents = f.read()
         self.name_stack = []


### PR DESCRIPTION
* Reduce noisiness of call graph generation output by removing statement that prints filenames as they are being processed.

Before:

![Screenshot 2025-02-18 at 4 05 33 PM](https://github.com/user-attachments/assets/68d39308-9088-4fc5-b1cd-e49a9ca3c781)

After:

![Screenshot 2025-02-18 at 4 05 46 PM](https://github.com/user-attachments/assets/43b8ab77-d58d-4ffc-bb22-24e19171c317)

Addresses https://github.com/nuanced-dev/nuanced-graph/issues/18
