### PR TITLE
Ensure indexed functions are included in module methods

### DIFF
--- a/src/jarviscg/processing/extProcessor.py
+++ b/src/jarviscg/processing/extProcessor.py
@@ -259,6 +259,7 @@ class ExtProcessor(ProcessingBase):
                 for indexed_function, referenced_function in indexed_functions.items():
                     indexed_function_defi = self.def_manager.get(indexed_function) or self.def_manager.create(indexed_function, utils.constants.FUN_DEF)
                     referenced_function_defi = self.def_manager.get(referenced_function) or self.def_manager.create(referenced_function, utils.constants.FUN_DEF)
+                    mod.add_method(indexed_function_defi.get_ns())
 
                     self.cg.add_edge(indexed_function_defi.get_ns(), referenced_function_defi.get_ns())
 


### PR DESCRIPTION
## Why?

When I started using nuanced to generate graphs using the most recent version jarviscg I found the graphs did not include edges between indexed functions and the functions they reference. Support for including these edges was added in https://github.com/nuanced-dev/jarviscg/pull/18, but it turns out the `jarviscg.formats.Simple` formatter used in `call_graph_generator_test.py`, which I used to verify the behavior of `CallGraphGenerator`, and the `jarviscg.formats.Nuanced` formatter used in the nuanced package handle these edges differently:

- `jarviscg.formats.Simple` uses the return value of `CallGraphGenerator#output` to build a graph of fully qualified function names
- `jarviscg.formats.Nuanced` uses the return value of `CallGraphGenerator#get_internal_mods` to build the graph because `get_internal_mods` includes both fully qualified function names _and_ filenames
- BUT if a function isn't added to the in-memory representation `CallGraphGenerator` builds with `ExtProcessor` as it traverses files, the function isn't present in the return value of `get_internal_mods`

## How?

- Update test so it's making an assertion about the `CallGraphGenerator` instance's internal state instead of what `jarviscg.formats.Simple` returns
- Update `ExtProcessor#visit_Module` to add indexed functions parsed from `__all__` lists in `__init__.py` files using jarviscg's `Module#add_method`