### PR TITLE
Tests exercising aliased classes and pytest test scenarios

### DIFF
--- a/tests/fixtures/fixture_class.py
+++ b/tests/fixtures/fixture_class.py
@@ -2,10 +2,10 @@ from datetime import datetime
 
 class FixtureClass():
     def __init__(self):
-        self.tzinfo = None
+        self.current_time = None
 
     def foo(self) -> None:
-        self.tzinfo = datetime.tzinfo()
+        self.current_time = datetime.now()
 
     def bar(self) -> None:
         self.foo()

--- a/tests/fixtures/other_fixture_class.py
+++ b/tests/fixtures/other_fixture_class.py
@@ -1,6 +1,6 @@
-from fixtures.fixture_class import FixtureClass
+from tests.fixtures.fixture_class import FixtureClass as AliasedFixtureClass
 
 class OtherFixtureClass():
     def baz(self) -> None:
-        ins = FixtureClass()
+        ins = AliasedFixtureClass()
         ins.bar()

--- a/tests/fixtures/other_fixture_class.py
+++ b/tests/fixtures/other_fixture_class.py
@@ -1,4 +1,4 @@
-from tests.fixtures.fixture_class import FixtureClass as AliasedFixtureClass
+from fixtures.fixture_class import FixtureClass as AliasedFixtureClass
 
 class OtherFixtureClass():
     def baz(self) -> None:

--- a/tests/fixtures/tests/example_test.py
+++ b/tests/fixtures/tests/example_test.py
@@ -1,0 +1,10 @@
+import pytest
+from tests.fixtures.fixture_class import FixtureClass
+
+@pytest.mark.skip(reason="This is a fixture")
+def test_fixture_class_foo_sets_current_time() -> None:
+    ins = FixtureClass().foo()
+
+    ins.foo()
+
+    assert ins.current_time

--- a/tests/jarviscg/call_graph_generator_test.py
+++ b/tests/jarviscg/call_graph_generator_test.py
@@ -41,9 +41,9 @@ def test_call_graph_generator_includes_indexed_functions() -> None:
 def test_call_graph_generator_includes_refs_to_aliased_classes() -> None:
     caller_of_aliased_class = "fixtures.other_fixture_class.OtherFixtureClass.baz"
     entrypoints = [
-            "./fixtures/__init__.py",
-            "./fixtures/fixture_class.py",
-            "./fixtures/other_fixture_class.py",
+        "./fixtures/__init__.py",
+        "./fixtures/fixture_class.py",
+        "./fixtures/other_fixture_class.py",
     ]
 
     cg = CallGraphGenerator(entrypoints, None)
@@ -53,4 +53,41 @@ def test_call_graph_generator_includes_refs_to_aliased_classes() -> None:
 
     assert "fixtures.fixture_class.FixtureClass.bar" in output[caller_of_aliased_class]
     assert "fixtures.fixture_class.FixtureClass.bar" in output.keys()
-    assert alias_name not in output.keys()
+
+def test_call_graph_generator_default_builds_incomplete_graph_for_pytest_file() -> None:
+    entrypoints = [
+        "./fixtures/tests/__init__.py",
+        "./fixtures/tests/example_test.py",
+        "./fixtures/fixture_class.py",
+    ]
+
+    cg = CallGraphGenerator(entrypoints, None)
+    cg.analyze()
+    formatter = formats.Simple(cg)
+    output = formatter.generate()
+
+    test_function_callees = output["fixtures.tests.example_test.test_fixture_class_foo_sets_current_time"]
+    assert test_function_callees == ["tests.fixtures.fixture_class.FixtureClass"]
+    assert "tests.fixtures.fixture_class.FixtureClass" in output.keys()
+
+def test_call_graph_generator_with_decy_true_builds_complete_graph_for_pytest_file() -> None:
+    entrypoints = [
+        "./fixtures/tests/__init__.py",
+        "./fixtures/tests/example_test.py",
+        "./fixtures/fixture_class.py",
+    ]
+    expected_callees = [
+        "tests.fixtures.fixture_class.FixtureClass.__init__",
+        "tests.fixtures.fixture_class.FixtureClass.foo",
+    ]
+
+    cg = CallGraphGenerator(entrypoints, None, decy=True)
+    cg.analyze()
+    formatter = formats.Simple(cg)
+    output = formatter.generate()
+
+    test_function_callees = output["fixtures.tests.example_test.test_fixture_class_foo_sets_current_time"]
+    diff = DeepDiff(test_function_callees, expected_callees, ignore_order=True)
+    assert diff == {}
+    for callee in test_function_callees:
+        assert callee in output.keys()

--- a/tests/jarviscg/call_graph_generator_test.py
+++ b/tests/jarviscg/call_graph_generator_test.py
@@ -37,3 +37,20 @@ def test_call_graph_generator_includes_indexed_functions() -> None:
     diff = DeepDiff(expected, internal_mods)
 
     assert diff == {}
+
+def test_call_graph_generator_includes_refs_to_aliased_classes() -> None:
+    caller_of_aliased_class = "fixtures.other_fixture_class.OtherFixtureClass.baz"
+    entrypoints = [
+            "./fixtures/__init__.py",
+            "./fixtures/fixture_class.py",
+            "./fixtures/other_fixture_class.py",
+    ]
+
+    cg = CallGraphGenerator(entrypoints, None)
+    cg.analyze()
+    formatter = formats.Simple(cg)
+    output = formatter.generate()
+
+    assert "fixtures.fixture_class.FixtureClass.bar" in output[caller_of_aliased_class]
+    assert "fixtures.fixture_class.FixtureClass.bar" in output.keys()
+    assert alias_name not in output.keys()


### PR DESCRIPTION
## Why?

We're increasing jarviscg's test coverage to improve our understanding of its behavior and limitations.

## How?

Test scenarios covering:
- What happens when a class is imported and aliased: `from foo import bar as baz`
- What happens when a method defining a pytest test scenario is analyzed with `decy=False` (the default setting)
- What happens when a method defining a pytest test scenario is analyzed with `decy=True`