### PR TITLE
Minor update to Setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ options:
 ```bash
 % cd jarviscg
 % uv venv
-% source .venv.bin/activate
+% source .venv/bin/activate
 % uv sync
 ```
 
 ## Running pytest tests
 
 ```bash
-% source .venv.bin/activate
+% source .venv/bin/activate
 % pytest tests/
 ```


### PR DESCRIPTION
I was working through the README and noticed in the Setup that we had `.venv.bin` instead of `.venv/bin`.  I think it wasn't intentional 😄