### PR TITLE
formats.Nuanced exposes function node line numbers

### DIFF
--- a/src/jarviscg/formats/nuanced.py
+++ b/src/jarviscg/formats/nuanced.py
@@ -14,7 +14,9 @@ class Nuanced(BaseFormatter):
             for namespace, info in module["methods"].items():
                 output[namespace] = {
                     "filepath": os.path.abspath(module["filename"]),
-                    "callees": []
+                    "callees": [],
+                    "lineno": info["first"],
+                    "end_lineno": info["last"],
                 }
 
         for src, dst in self.edges:

--- a/tests/jarviscg/formats/nuanced_test.py
+++ b/tests/jarviscg/formats/nuanced_test.py
@@ -12,7 +12,7 @@ def change_directory():
     yield
     os.chdir("../")
 
-def test_nuanced_formatter_includes_filenames() -> None:
+def test_nuanced_formatter_formats_graph() -> None:
     entrypoints = [
         "./fixtures/fixture_class.py",
         "./fixtures/other_fixture_class.py",
@@ -21,26 +21,38 @@ def test_nuanced_formatter_includes_filenames() -> None:
         "fixtures.fixture_class": {
             "filepath": os.path.abspath("fixtures/fixture_class.py"),
             "callees": ["fixtures.fixture_class.FixtureClass"],
+            "lineno": 1,
+            "end_lineno": 11
         },
         "fixtures.other_fixture_class": {
             "filepath": os.path.abspath("fixtures/other_fixture_class.py"),
             "callees": ["fixtures.other_fixture_class.OtherFixtureClass"],
+            "lineno": 1,
+            "end_lineno": 6
         },
         "fixtures.other_fixture_class.OtherFixtureClass.baz": {
             "filepath": os.path.abspath("fixtures/other_fixture_class.py"),
             "callees": ["fixtures.fixture_class.FixtureClass.bar", "fixtures.fixture_class.FixtureClass.__init__"],
+            "lineno": 4,
+            "end_lineno": 6
         },
         "fixtures.fixture_class.FixtureClass.__init__": {
             "filepath": os.path.abspath("fixtures/fixture_class.py"),
             "callees": [],
+            "lineno": 4,
+            "end_lineno": 5
         },
         "fixtures.fixture_class.FixtureClass.bar": {
             "filepath": os.path.abspath("fixtures/fixture_class.py"),
             "callees": ["fixtures.fixture_class.FixtureClass.foo"],
+            "lineno": 10,
+            "end_lineno": 11
         },
         "fixtures.fixture_class.FixtureClass.foo": {
             "filepath": os.path.abspath("fixtures/fixture_class.py"),
             "callees": [],
+            "lineno": 7,
+            "end_lineno": 8
         }
     }
     cg = CallGraphGenerator(entrypoints, None)


### PR DESCRIPTION
## Why?

Client applications need a way to uniquely identify functions in the call graph without having to construct the fully qualified function name, e.g. `mod1.mod2.file.MyClass.fn_name`.

## How?

Include functions' start and end line numbers in output formatted by `formats.Nuanced`. Since file paths are already included in the output, functions can be uniquely identified by their file path, `lineno` and `end_lineno`.

References:
- [Python ast docs](https://docs.python.org/3/library/ast.html#ast.AST.lineno)