### PR TITLE
Bump version to 0.1.0rc2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/version_bump_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/version_bump_template.md
@@ -1,0 +1,16 @@
+Pre-review checklist:
+- [ ] The version number in `pyproject.toml` has been updated
+- [ ] `__version__` in `src/jarviscg/__init__.py` has been updated
+- [ ] `uv.lock` has been updated by running `uv sync`
+- [ ] `CHANGELOG.md` has been updated
+
+Post-merge checklist:
+- [ ] Create GitHub Release
+- [ ] Publish package to TestPyPI
+- [ ] Publish package to PyPI
+- [ ] Verify installation
+  - [ ] `pip install jarviscg`
+  - [ ] `uv tool install jarviscg`
+
+References:
+ - [nuanced Release Process](https://docs.nuanced.dev/versioning#release-process)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0rc2] - 2025-03-27
+
+### Added
+
+- `jarviscg.formats.Nuanced` call graph formatter exposes function start and end line numbers (https://github.com/nuanced-dev/jarviscg/pull/24)
+
+### Fixed
+
+### Changed
+
+### Removed
+
 ## [0.1.0rc1] - 2025-03-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jarviscg"
-version = "0.1.0rc1"
+version = "0.1.0rc2"
 description = "Call graph generator for Python forked from pythonJaRvis/pythonJaRvis.github.io"
 readme = "README.md"
 authors = [

--- a/src/jarviscg/__init__.py
+++ b/src/jarviscg/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.0rc1"
+__version__ = "0.1.0rc2"

--- a/uv.lock
+++ b/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "jarviscg"
-version = "0.1.0rc1"
+version = "0.1.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "deepdiff" },


### PR DESCRIPTION
Pre-review checklist:
- [x] The version number in `pyproject.toml` has been updated
- [x] `__version__` in `src/jarviscg/__init__.py` has been updated
- [x] `uv.lock` has been updated by running `uv sync`
- [x] `CHANGELOG.md` has been updated

Post-merge checklist:
- [ ] Create GitHub Release
- [ ] Publish package to TestPyPI
- [ ] Publish package to PyPI
- [ ] Verify installation
  - [ ] `pip install jarviscg`
  - [ ] `uv tool install jarviscg`

References:
 - [nuanced Release Process](https://docs.nuanced.dev/versioning#release-process)