### PR TITLE
Ensure inputs to CallGraphGenerator::analyze_localfunction are ordered

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "pytest>=8.3.4",
+    "pytest-mock>=3.14.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/jarviscg/core.py
+++ b/src/jarviscg/core.py
@@ -103,6 +103,7 @@ class CallGraphGenerator(object):
         self, cls, install_hooks=False, modules_analyzed=set(), *args, **kwargs
     ):
         modules_analyzed = modules_analyzed
+        modules_by_order_analyzed = list()
         processor: ExtProcessor = None
         input_pkg = None
         for entry_point in self.entry_points:
@@ -127,6 +128,7 @@ class CallGraphGenerator(object):
             self.module_manager.add_local_modules(input_mod)
             processor.analyze()
             modules_analyzed = modules_analyzed.union(processor.get_modules_analyzed())
+            modules_by_order_analyzed.append(input_mod)
             if install_hooks:
                 self.remove_import_hooks()
         if install_hooks:
@@ -134,7 +136,7 @@ class CallGraphGenerator(object):
             self.import_manager.install_hooks()
         if not self.moduleEntry:
             self.moduleEntry = []
-            for local in self.module_manager.local:
+            for local in modules_by_order_analyzed:
                 moduleNode = self.module_manager.get(local)
                 if not moduleNode:
                     continue
@@ -220,4 +222,3 @@ class CallGraphGenerator(object):
         group_items_ordered_alphabetically = [sorted(g[1]) for g in groups_ordered_by_depth_desc]
         flattened = list(itertools.chain.from_iterable(group_items_ordered_alphabetically))
         return flattened
-

--- a/tests/jarviscg/call_graph_generator_test.py
+++ b/tests/jarviscg/call_graph_generator_test.py
@@ -93,7 +93,7 @@ def test_call_graph_generator_with_decy_true_builds_complete_graph_for_pytest_fi
     for callee in test_function_callees:
         assert callee in output.keys()
 
-def test_module_order(mocker) -> None:
+def test_do_pass_processes_modules_in_order_files_were_processed(mocker) -> None:
     mock_module_node = mocker.MagicMock()
     mock_module_node.get_methods.side_effect = [
         {"fixtures.tests": {}},

--- a/tests/jarviscg/call_graph_generator_test.py
+++ b/tests/jarviscg/call_graph_generator_test.py
@@ -2,8 +2,9 @@ from deepdiff import DeepDiff
 import glob
 import os
 import pytest
-from jarviscg.core import CallGraphGenerator
 from jarviscg import formats
+from jarviscg.core import CallGraphGenerator
+from jarviscg.processing.extProcessor import ExtProcessor
 
 # Necessary because CallGraphGenerator expects to be running one directory
 # up from shallowest module definitions
@@ -91,3 +92,40 @@ def test_call_graph_generator_with_decy_true_builds_complete_graph_for_pytest_fi
     assert diff == {}
     for callee in test_function_callees:
         assert callee in output.keys()
+
+def test_module_order(mocker) -> None:
+    mock_module_node = mocker.MagicMock()
+    mock_module_node.get_methods.side_effect = [
+        {"fixtures.tests": {}},
+        {"fixtures.tests.example_test": {}},
+        {"fixtures.fixture_class": {}},
+    ]
+    mock_module_manager = mocker.MagicMock()
+    mock_module_manager.get.return_value = mock_module_node
+    mock_processor_class = mocker.patch("jarviscg.processing.extProcessor.ExtProcessor")
+    entrypoints = [
+        "./fixtures/tests/__init__.py",
+        "./fixtures/tests/example_test.py",
+        "./fixtures/fixture_class.py",
+    ]
+    expected_modules = ["fixtures.tests", "fixtures.tests.example_test", "fixtures.fixture_class"]
+
+    cg = CallGraphGenerator(entrypoints, None)
+    cg.module_manager = mock_module_manager
+    cg.do_pass(
+        mock_processor_class,
+        True,
+        set(),
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+        mock_module_manager,
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+    )
+
+    analyze_localfunction_args = mock_processor_class.mock_calls[-1].args[0]
+    diff = DeepDiff(expected_modules, analyze_localfunction_args)
+    assert diff == {}

--- a/uv.lock
+++ b/uv.lock
@@ -58,6 +58,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-mock" },
 ]
 
 [package.metadata]
@@ -68,7 +69,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.4" }]
+dev = [
+    { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-mock", specifier = ">=3.14.0" },
+]
 
 [[package]]
 name = "orderly-set"
@@ -112,6 +116,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/90/a955c3ab35ccd41ad4de556596fa86685bf4fc5ffcc62d22d856cfd4e29a/pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0", size = 32814 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/3b/b26f90f74e2986a82df6e7ac7e319b8ea7ccece1caec9f8ab6104dc70603/pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f", size = 9863 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why?

Currently `CallGraphGenerator::do_pass` invokes `CallGraphGenerator::analyze_localfunction` with a collection that is constructed by iterating over `self.module_manager.locals`. `self.module_manager.locals` is a set, and sets are unordered in Python, so the order in which modules are processed by `analyze_localfunction` is non-deterministic. This contributes to non-determinism in call graph generation.

## How?

Since we are already ordering the files passed to the call graph generator in [`_depth_first_by_directory`](https://github.com/nuanced-dev/jarviscg/blob/main/src/jarviscg/core.py#L214-L222) (introduced in https://github.com/nuanced-dev/jarviscg/pull/17), we should be able to simply update `CallGraphGenerator::do_pass` to keep track of the order in which the modules are processed. This PR introduces a new local variable `modules_by_order_analyzed`: a list to which fully qualified module names are appended after they are processed. And instead of iterating over the set `self.module_manager.local`, we iterate over the ordered list `modules_by_order_analyzed` to build the collection passed to `analyze_localfunction`.

## Considerations

### Testing

Spent some time trying to write a test exercising `do_pass` and as usual got stuck trying to get the mock setup right. I'll keep trying.

<details><summary>It will look something like this 👇 </summary>

```python
def test_module_order(mocker) -> None:
    mock_processor_class = mocker.patch("jarviscg.processing.extProcessor.ExtProcessor")
    entrypoints = [
        "./fixtures/tests/__init__.py",
        "./fixtures/tests/example_test.py",
        "./fixtures/fixture_class.py",
    ]

    cg = CallGraphGenerator(entrypoints, None)
    cg.do_pass(
        mock_processor_class,
        True,
        set(),
        mocker.Mock(),
        mocker.Mock(),
        mocker.Mock(),
        mocker.Mock(),
        mocker.Mock(),
        mocker.Mock(),
        mocker.Mock(),
        mocker.Mock(),
    )
    
    # assert mock processor called with correctly ordered modules
```
</details>

### Mitigating unexpected side effects

- I confirmed `do_pass` is the only place `add_local_modules` is invoked and there's nothing in the codebase that calls `remove` on `module_manager.locals`, so I don't think `module_manager.locals` is being mutated outside the scope of `do_pass`

Addresses https://github.com/nuanced-dev/nuanced/issues/61