### PR TITLE
Tests include edges to aliased nodes by passing `package` option to call graph generator

### DIFF
--- a/tests/fixtures/lazyframe/__init__.py
+++ b/tests/fixtures/lazyframe/__init__.py
@@ -1,5 +1,1 @@
-from fixtures.lazyframe.frame import LazyFrame
-
-__all__ = [
-    "LazyFrame",
-]
+from fixtures.lazyframe.frame import *

--- a/tests/jarviscg/call_graph_generator_test.py
+++ b/tests/jarviscg/call_graph_generator_test.py
@@ -7,41 +7,34 @@ from jarviscg.core import CallGraphGenerator
 from jarviscg.processing.extProcessor import ExtProcessor
 
 
-# Necessary because CallGraphGenerator expects to be running one directory
-# up from shallowest module definitions
-@pytest.fixture(autouse=True)
-def change_directory():
-    os.chdir("tests")
-    yield
-    os.chdir("../")
-
-def test_call_graph_generator_excludes_calls_to_methods_of_aliased_class() -> None:
+def test_call_graph_generator_includes_calls_to_methods_of_aliased_module() -> None:
     # Fixture setup:
-    # - `fixtures/lazyframe/__init__.py` exports `LazyFrame` using `__all__`
+    # - `fixtures/lazyframe/__init__.py` exports `*`
     # - `klass.py` imports `LazyFrame` from `fixtures`
     # - `Klass#other_method` invokes `LazyFrame.from_list` class method and
     # `LazyFrame#group_by` instance method
-
     entrypoints = [
-            "./fixtures/__init__.py",
-            "./fixtures/lazyframe/__init__.py",
-            "./fixtures/lazyframe/frame.py",
-            "./fixtures/core/__init__.py",
-            "./fixtures/core/nested/klass.py",
-            "./fixtures/core/nested/__init__.py",
+            "./tests/__init__.py",
+            "./tests/fixtures/__init__.py",
+            "./tests/fixtures/lazyframe/__init__.py",
+            "./tests/fixtures/lazyframe/frame.py",
+            "./tests/fixtures/core/__init__.py",
+            "./tests/fixtures/core/nested/klass.py",
+            "./tests/fixtures/core/nested/__init__.py",
     ]
+    package = "tests"
     caller = "fixtures.core.nested.klass.Klass.other_method"
-    invoked_class_method = "fixtures.lazyframe.LazyFrame.from_list"
-    invoked_instance_method = "fixtures.lazyframe.LazyFrame.group_by"
-    cg = CallGraphGenerator(entrypoints, None)
+    invoked_class_method = "fixtures.lazyframe.frame.LazyFrame.from_list"
+    invoked_instance_method = "fixtures.lazyframe.frame.LazyFrame.group_by"
+    cg = CallGraphGenerator(entrypoints, package)
     cg.analyze()
     formatter = formats.Simple(cg)
     output = formatter.generate()
 
     for callee in [invoked_class_method, invoked_instance_method]:
-        assert callee not in output[caller]
+        assert callee in output[caller]
 
-def test_call_graph_generator_includes_indexed_functions() -> None:
+def test_call_graph_generator_includes_aliased_functions() -> None:
     # Fixture setup:
     # - `klass.py` imports `parse_into_list_of_expressions` from `_utils.parse`
     # - `Klass#method` invokes `parse.expr.parse_into_list_of_expressions`
@@ -49,32 +42,35 @@ def test_call_graph_generator_includes_indexed_functions() -> None:
     # using `__all__`
 
     entrypoints = [
-            "./fixtures/__init__.py",
-            "./fixtures/_utils/parse/expr.py",
-            "./fixtures/_utils/__init__.py",
-            "./fixtures/_utils/parse/__init__.py",
-            "./fixtures/core/__init__.py",
-            "./fixtures/core/nested/klass.py",
-            "./fixtures/core/nested/__init__.py",
+            "./tests/__init__.py",
+            "./tests/fixtures/__init__.py",
+            "./tests/fixtures/_utils/parse/expr.py",
+            "./tests/fixtures/_utils/__init__.py",
+            "./tests/fixtures/_utils/parse/__init__.py",
+            "./tests/fixtures/core/__init__.py",
+            "./tests/fixtures/core/nested/klass.py",
+            "./tests/fixtures/core/nested/__init__.py",
     ]
-    expected = {'fixtures.core.nested': {'filename': 'fixtures/core/nested/__init__.py', 'methods': {'fixtures.core.nested': {'name': 'fixtures.core.nested', 'first': 0, 'last': 0}}}, 'fixtures.core.nested.klass': {'filename': 'fixtures/core/nested/klass.py', 'methods': {'fixtures.core.nested.klass': {'name': 'fixtures.core.nested.klass', 'first': 1, 'last': 12}, 'fixtures.core.nested.klass.Klass.method': {'name': 'fixtures.core.nested.klass.Klass.method', 'first': 6, 'last': 7}, 'fixtures.core.nested.klass.Klass.other_method': {'name': 'fixtures.core.nested.klass.Klass.other_method', 'first': 9, 'last': 12}}}, 'fixtures._utils.parse': {'filename': 'fixtures/_utils/parse/__init__.py', 'methods': {'fixtures._utils.parse': {'name': 'fixtures._utils.parse', 'first': 1, 'last': 8}, 'fixtures._utils.parse.parse_into_list_of_expressions': {'name': 'fixtures._utils.parse.parse_into_list_of_expressions', 'first': None, 'last': None}}}, 'fixtures._utils.parse.expr': {'filename': 'fixtures/_utils/parse/expr.py', 'methods': {'fixtures._utils.parse.expr': {'name': 'fixtures._utils.parse.expr', 'first': 1, 'last': 9}, 'fixtures._utils.parse.expr.parse_into_list_of_expressions': {'name': 'fixtures._utils.parse.expr.parse_into_list_of_expressions', 'first': 1, 'last': 6}, 'fixtures._utils.parse.expr._parse_positional_inputs': {'name': 'fixtures._utils.parse.expr._parse_positional_inputs', 'first': 8, 'last': 9}}}, 'fixtures.core': {'filename': 'fixtures/core/__init__.py', 'methods': {'fixtures.core': {'name': 'fixtures.core', 'first': 0, 'last': 0}}}, 'fixtures._utils': {'filename': 'fixtures/_utils/__init__.py', 'methods': {'fixtures._utils': {'name': 'fixtures._utils', 'first': 0, 'last': 0}}}, 'fixtures': {'filename': 'fixtures/__init__.py', 'methods': {'fixtures': {'name': 'fixtures', 'first': 0, 'last': 0}}}}
-    cg = CallGraphGenerator(entrypoints, None)
+    package = "tests"
+    cg = CallGraphGenerator(entrypoints, package)
     cg.analyze()
 
-    internal_mods = cg.output_internal_mods()
-    diff = DeepDiff(expected, internal_mods)
+    formatter = formats.Simple(cg)
+    output = formatter.generate()
 
-    assert diff == {}
+    assert output["fixtures.core.nested.klass.Klass.method"] == ["fixtures._utils.parse.parse_into_list_of_expressions"]
+    assert output["fixtures._utils.parse.parse_into_list_of_expressions"] == ["fixtures._utils.parse.expr.parse_into_list_of_expressions"]
 
 def test_call_graph_generator_includes_refs_to_aliased_classes() -> None:
     caller_of_aliased_class = "fixtures.other_fixture_class.OtherFixtureClass.baz"
+    package = "tests"
     entrypoints = [
-        "./fixtures/__init__.py",
-        "./fixtures/fixture_class.py",
-        "./fixtures/other_fixture_class.py",
+        "./tests/fixtures/__init__.py",
+        "./tests/fixtures/fixture_class.py",
+        "./tests/fixtures/other_fixture_class.py",
     ]
 
-    cg = CallGraphGenerator(entrypoints, None)
+    cg = CallGraphGenerator(entrypoints, package)
     cg.analyze()
     formatter = formats.Simple(cg)
     output = formatter.generate()
@@ -82,77 +78,25 @@ def test_call_graph_generator_includes_refs_to_aliased_classes() -> None:
     assert "fixtures.fixture_class.FixtureClass.bar" in output[caller_of_aliased_class]
     assert "fixtures.fixture_class.FixtureClass.bar" in output.keys()
 
-def test_call_graph_generator_default_builds_incomplete_graph_for_pytest_file() -> None:
+def test_call_graph_generator_default_builds_complete_graph_for_pytest_file() -> None:
+    package = "tests"
     entrypoints = [
-        "./fixtures/tests/__init__.py",
-        "./fixtures/tests/example_test.py",
-        "./fixtures/fixture_class.py",
-    ]
-
-    cg = CallGraphGenerator(entrypoints, None)
-    cg.analyze()
-    formatter = formats.Simple(cg)
-    output = formatter.generate()
-
-    test_function_callees = output["fixtures.tests.example_test.test_fixture_class_foo_sets_current_time"]
-    assert test_function_callees == ["tests.fixtures.fixture_class.FixtureClass"]
-    assert "tests.fixtures.fixture_class.FixtureClass" in output.keys()
-
-def test_call_graph_generator_with_decy_true_builds_complete_graph_for_pytest_file() -> None:
-    entrypoints = [
-        "./fixtures/tests/__init__.py",
-        "./fixtures/tests/example_test.py",
-        "./fixtures/fixture_class.py",
+        "./tests/fixtures/tests/__init__.py",
+        "./tests/fixtures/tests/example_test.py",
+        "./tests/fixtures/fixture_class.py",
     ]
     expected_callees = [
-        "tests.fixtures.fixture_class.FixtureClass.__init__",
-        "tests.fixtures.fixture_class.FixtureClass.foo",
+        "fixtures.fixture_class.FixtureClass.__init__",
+        "fixtures.fixture_class.FixtureClass.foo",
+        "tests.fixtures.fixture_class.FixtureClass",
     ]
 
-    cg = CallGraphGenerator(entrypoints, None, decy=True)
+    cg = CallGraphGenerator(entrypoints, package)
     cg.analyze()
     formatter = formats.Simple(cg)
     output = formatter.generate()
 
     test_function_callees = output["fixtures.tests.example_test.test_fixture_class_foo_sets_current_time"]
-    diff = DeepDiff(test_function_callees, expected_callees, ignore_order=True)
-    assert diff == {}
-    for callee in test_function_callees:
-        assert callee in output.keys()
-
-def test_do_pass_processes_modules_in_order_files_were_processed(mocker) -> None:
-    mock_module_node = mocker.MagicMock()
-    mock_module_node.get_methods.side_effect = [
-        {"fixtures.tests": {}},
-        {"fixtures.tests.example_test": {}},
-        {"fixtures.fixture_class": {}},
-    ]
-    mock_module_manager = mocker.MagicMock()
-    mock_module_manager.get.return_value = mock_module_node
-    mock_processor_class = mocker.patch("jarviscg.processing.extProcessor.ExtProcessor")
-    entrypoints = [
-        "./fixtures/tests/__init__.py",
-        "./fixtures/tests/example_test.py",
-        "./fixtures/fixture_class.py",
-    ]
-    expected_modules = ["fixtures.tests", "fixtures.tests.example_test", "fixtures.fixture_class"]
-
-    cg = CallGraphGenerator(entrypoints, None)
-    cg.module_manager = mock_module_manager
-    cg.do_pass(
-        mock_processor_class,
-        True,
-        set(),
-        mocker.Mock(),
-        mocker.Mock(),
-        mocker.Mock(),
-        mocker.Mock(),
-        mock_module_manager,
-        mocker.Mock(),
-        mocker.Mock(),
-        mocker.Mock(),
-    )
-
-    analyze_localfunction_args = mock_processor_class.mock_calls[-1].args[0]
-    diff = DeepDiff(expected_modules, analyze_localfunction_args)
-    assert diff == {}
+    assert "tests.fixtures.fixture_class.FixtureClass" in output.keys()
+    for callee in expected_callees:
+        assert callee in test_function_callees


### PR DESCRIPTION
## Why?

Edges to methods of aliased classes aren't being included in call graphs: https://github.com/nuanced-dev/nuanced/issues/62.

## How?

On the plus side, no changes to jarviscg's internals are needed because jarviscg already persists information about the relationship of aliased behavior to aliases via:

`visit_Import`
--> `for import_item in node.names`
----> `handle_scopes(import_item.name, tgt_name, imported_name`
------> Create def and add “value point” associating alias and aliased https://github.com/nuanced-dev/jarviscg/blob/main/src/jarviscg/processing/extProcessor.py#L387-L391

However, it appears that jarviscg's handling of scopes becomes messed up when the `entry_points` and `package` passed to `CallGraphGenerator` don't have the expected relationship, producing a graph with missing edges.

The best way to illustrate this is with some tests. For example, this test (in this PR) passes:

```python
def test_call_graph_generator_includes_calls_to_methods_of_aliased_module() -> None:
    # Fixture setup:
    # - `fixtures/lazyframe/__init__.py` exports `*`
    # - `klass.py` imports `LazyFrame` from `fixtures`
    # - `Klass#other_method` invokes `LazyFrame.from_list` class method and
    # `LazyFrame#group_by` instance method
    entrypoints = [
            "./tests/__init__.py",
            "./tests/fixtures/__init__.py",
            "./tests/fixtures/lazyframe/__init__.py",
            "./tests/fixtures/lazyframe/frame.py",
            "./tests/fixtures/core/__init__.py",
            "./tests/fixtures/core/nested/klass.py",
            "./tests/fixtures/core/nested/__init__.py",
    ]
    package = "tests"
    caller = "fixtures.core.nested.klass.Klass.other_method"
    invoked_class_method = "fixtures.lazyframe.frame.LazyFrame.from_list"
    invoked_instance_method = "fixtures.lazyframe.frame.LazyFrame.group_by"
    cg = CallGraphGenerator(entrypoints, package)
    cg.analyze()
    formatter = formats.Simple(cg)
    output = formatter.generate()

    for callee in [invoked_class_method, invoked_instance_method]:
        assert callee in output[caller]
```

When we change the value of `package` to `None` and run the test, we find that the caller key has changed from `"fixtures.core.nested.klass.Klass.other_method"` to `"tests.fixtures.core.nested.klass.Klass.other_method"`. When we update the key and run the test again, we see it fail with `AssertionError: assert 'fixtures.lazyframe.frame.LazyFrame.from_list' in ['<builtin>.list']`.

## Integration testing

I verified that jarviscg generates a graph that includes the missing edge to a method of an aliased class described in https://github.com/nuanced-dev/nuanced/issues/62 when I take these steps:

```bash
% cd nuanced
% uv remove jarviscg
% uv add ../jarviscg # Adds the version of jarviscg on this branch
% cd src
% nuanced init .
% nuanced enrich nuanced/cli.py enrich | jq
```

<details><summary>Output 👇 </summary>

```json
{
  "nuanced.cli.enrich": {
    "filepath": "/Users/laila/Source/nuanced/nuanced/src/nuanced/cli.py",
    "callees": [
      "<builtin>.print",
      "nuanced.code_graph.CodeGraph.load",
      "<builtin>.len",
      "<builtin>.str"
    ],
    "lineno": 13,
    "end_lineno": 33
  },
  "nuanced.code_graph.CodeGraph.load": {
    "filepath": "/Users/laila/Source/nuanced/nuanced/src/nuanced/code_graph.py",
    "callees": [
      "nuanced.code_graph.CodeGraph.__init__",
      "<str>.join",
      "<builtin>.ValueError",
      "<builtin>.str",
      "<builtin>.len",
      "<builtin>.list",
      "<builtin>.FileNotFoundError",
      "<builtin>.open",
      "pathlib.Path",
      "append"
    ],
    "lineno": 67,
    "end_lineno": 86
  },
  "nuanced.code_graph.CodeGraph.__init__": {
    "filepath": "/Users/laila/Source/nuanced/nuanced/src/nuanced/code_graph.py",
    "callees": [],
    "lineno": 88,
    "end_lineno": 89
  }
}
```
</details>

### Next steps

- Open a PR removing the special processing for `__init__.py` files introduced in https://github.com/nuanced-dev/jarviscg/pull/18 because it turns out that special processing is redundant
- Figure out how to update nuanced and nuanced-python so they are running jarviscg with the `entry_points` and `package` jarviscg expects