### PR TITLE
Remove special handling of `__init__.py` files

### DIFF
--- a/src/jarviscg/utils/constants.py
+++ b/src/jarviscg/utils/constants.py
@@ -35,7 +35,6 @@ COPY_DEF        = "COPY"
 
 OBJECT_BASE     = "object"
 
-INIT_FILE_NAME  = "__init__.py"
 ALL_LIST_NAME   = "__all__"
 CLS_INIT        = "__init__"
 ITER_METHOD     = "__iter__"

--- a/tests/jarviscg/call_graph_generator_test.py
+++ b/tests/jarviscg/call_graph_generator_test.py
@@ -58,8 +58,8 @@ def test_call_graph_generator_includes_aliased_functions() -> None:
     formatter = formats.Simple(cg)
     output = formatter.generate()
 
-    assert output["fixtures.core.nested.klass.Klass.method"] == ["fixtures._utils.parse.parse_into_list_of_expressions"]
-    assert output["fixtures._utils.parse.parse_into_list_of_expressions"] == ["fixtures._utils.parse.expr.parse_into_list_of_expressions"]
+    assert output["fixtures.core.nested.klass.Klass.method"] == ["fixtures._utils.parse.expr.parse_into_list_of_expressions"]
+    assert output["fixtures._utils.parse.expr.parse_into_list_of_expressions"] == ["fixtures._utils.parse.expr._parse_positional_inputs"]
 
 def test_call_graph_generator_includes_refs_to_aliased_classes() -> None:
     caller_of_aliased_class = "fixtures.other_fixture_class.OtherFixtureClass.baz"


### PR DESCRIPTION
## Context

Special handling of `__init__.py` files was added in https://github.com/nuanced-dev/jarviscg/pull/18 when we didn't understand jarviscg's internals or usage very well and thought it wasn't including edges defined via aliases.

Since then we have learned that jarviscg does keep track of edges defined via aliases: the relevant code is in `ExtProcessor::visit_Import` and `ExtProcessor::visit_Import::handle_scopes`. This commit reverts the changes in #18.

Dependent on https://github.com/nuanced-dev/jarviscg/pull/30