### PR TITLE
Expose absolute instead of relative file paths in output

### DIFF
--- a/src/jarviscg/core.py
+++ b/src/jarviscg/core.py
@@ -181,7 +181,7 @@ class CallGraphGenerator(object):
         res = {}
         for mod, node in mods.items():
             res[mod] = {
-                "filename": os.path.relpath(node.get_filename(), self.package)
+                "filename": node.get_filename()
                 if node.get_filename()
                 else None,
                 "methods": node.get_methods(),

--- a/tests/jarviscg/formats/nuanced_test.py
+++ b/tests/jarviscg/formats/nuanced_test.py
@@ -4,18 +4,11 @@ import pytest
 from jarviscg.core import CallGraphGenerator
 from jarviscg import formats
 
-# Necessary because CallGraphGenerator expects to be running one directory
-# up from shallowest module definitions
-@pytest.fixture(autouse=True)
-def change_directory():
-    os.chdir("tests")
-    yield
-    os.chdir("../")
 
 def test_nuanced_formatter_formats_graph() -> None:
     entrypoints = [
-        "./fixtures/fixture_class.py",
-        "./fixtures/other_fixture_class.py",
+        "./tests/fixtures/fixture_class.py",
+        "./tests/fixtures/other_fixture_class.py",
     ]
     expected = {
         "fixtures.fixture_class": {
@@ -26,7 +19,7 @@ def test_nuanced_formatter_formats_graph() -> None:
         },
         "fixtures.other_fixture_class": {
             "filepath": os.path.abspath("fixtures/other_fixture_class.py"),
-            "callees": ["fixtures.other_fixture_class.OtherFixtureClass"],
+            "callees": ["fixtures.other_fixture_class.OtherFixtureClass", "fixtures.fixture_class"],
             "lineno": 1,
             "end_lineno": 6
         },
@@ -55,7 +48,7 @@ def test_nuanced_formatter_formats_graph() -> None:
             "end_lineno": 8
         }
     }
-    cg = CallGraphGenerator(entrypoints, None)
+    cg = CallGraphGenerator(entrypoints, "tests")
     cg.analyze()
 
     formatter = formats.Nuanced(cg)

--- a/tests/jarviscg/formats/nuanced_test.py
+++ b/tests/jarviscg/formats/nuanced_test.py
@@ -12,37 +12,37 @@ def test_nuanced_formatter_formats_graph() -> None:
     ]
     expected = {
         "fixtures.fixture_class": {
-            "filepath": os.path.abspath("fixtures/fixture_class.py"),
+            "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": ["fixtures.fixture_class.FixtureClass"],
             "lineno": 1,
             "end_lineno": 11
         },
         "fixtures.other_fixture_class": {
-            "filepath": os.path.abspath("fixtures/other_fixture_class.py"),
+            "filepath": os.path.abspath("tests/fixtures/other_fixture_class.py"),
             "callees": ["fixtures.other_fixture_class.OtherFixtureClass", "fixtures.fixture_class"],
             "lineno": 1,
             "end_lineno": 6
         },
         "fixtures.other_fixture_class.OtherFixtureClass.baz": {
-            "filepath": os.path.abspath("fixtures/other_fixture_class.py"),
+            "filepath": os.path.abspath("tests/fixtures/other_fixture_class.py"),
             "callees": ["fixtures.fixture_class.FixtureClass.bar", "fixtures.fixture_class.FixtureClass.__init__"],
             "lineno": 4,
             "end_lineno": 6
         },
         "fixtures.fixture_class.FixtureClass.__init__": {
-            "filepath": os.path.abspath("fixtures/fixture_class.py"),
+            "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": [],
             "lineno": 4,
             "end_lineno": 5
         },
         "fixtures.fixture_class.FixtureClass.bar": {
-            "filepath": os.path.abspath("fixtures/fixture_class.py"),
+            "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": ["fixtures.fixture_class.FixtureClass.foo"],
             "lineno": 10,
             "end_lineno": 11
         },
         "fixtures.fixture_class.FixtureClass.foo": {
-            "filepath": os.path.abspath("fixtures/fixture_class.py"),
+            "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": [],
             "lineno": 7,
             "end_lineno": 8


### PR DESCRIPTION
## Why?

We want nuanced to standardize on setting jarviscg's `package` option when generating call graphs because limiting the analysis to a specific package makes it easier to reason about jarviscg's analysis and output. However, module `filepath`s exposed in the `formats.Nuanced` output is incorrectly constructed when the `package` option is set.

As the test in this PR shows, running `CallGraphGenerator(["./tests/fixtures/fixture_class.py", "./tests/fixtures/other_fixture_class.py"], "tests").analyze()`, where `"tests"` is the package path, produces output with file paths that are incorrect because they omit the `tests` directory.

## How?

Update `CallGraphGenerator::_generate_mods` to set `"filename"` to `node.get_filename()` instead of `os.path.relpath(node.get_filename(), self.package)`.

## Considerations

Does this break anything? I don't think so: grepping for `'\["filename"\]'` and `\.get_filename` doesn't surface anything that looks like it depends on the value of `"filename"` being a possibly incorrect relative path.

```bash
(jarviscg) jarviscg lw-filepath % git grep '\["filename"\]' src/jarviscg/
src/jarviscg/formats/fasten.py:            filename = module["filename"]
src/jarviscg/formats/nuanced.py:                    "filepath": os.path.abspath(module["filename"]),
src/jarviscg/machinery/imports.py:            return self.import_graph[modname]["filename"]
src/jarviscg/machinery/imports.py:        node["filename"] = os.path.abspath(filename)
(jarviscg) jarviscg lw-filepath % git grep '\.get_filename' src/jarviscg/
src/jarviscg/core.py:                "filename": node.get_filename()
src/jarviscg/core.py:                if node.get_filename()
```

Part of https://github.com/nuanced-dev/nuanced/issues/52