### PR TITLE
Add tests documenting behavior of `decy` option

### DIFF
--- a/tests/fixtures/fixture_class.py
+++ b/tests/fixtures/fixture_class.py
@@ -1,10 +1,12 @@
 from datetime import datetime
+from functools import cache
 
 class FixtureClass():
     def __init__(self):
         self.current_time = None
 
     def foo(self) -> None:
+        cache(self.foo)
         self.current_time = datetime.now()
 
     def bar(self) -> None:

--- a/tests/fixtures/fixture_class.py
+++ b/tests/fixtures/fixture_class.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from functools import cache
+from multiprocessing import Process
 
 class FixtureClass():
     def __init__(self):
@@ -7,6 +8,7 @@ class FixtureClass():
 
     def foo(self) -> None:
         cache(self.foo)
+        Process()
         self.current_time = datetime.now()
 
     def bar(self) -> None:

--- a/tests/jarviscg/call_graph_generator_test.py
+++ b/tests/jarviscg/call_graph_generator_test.py
@@ -110,7 +110,7 @@ def test_call_graph_generator_dependency_analysis_disabled() -> None:
     ]
     dependency_called_function_name = "functools.cache"
     dependency_called_attribute_name = "datetime.datetime.now"
-    imported_called_name = "multiprocessing.Process"
+    imported_called_constructor_name = "multiprocessing.Process"
 
     cg = CallGraphGenerator(entrypoints, package)
     cg.analyze()
@@ -119,7 +119,7 @@ def test_call_graph_generator_dependency_analysis_disabled() -> None:
 
     callees = output["fixtures.fixture_class.FixtureClass.foo"]
     assert dependency_called_attribute_name not in callees
-    assert imported_called_name in callees
+    assert imported_called_constructor_name in callees
     assert dependency_called_function_name in callees
     assert output[dependency_called_function_name] == []
 
@@ -132,7 +132,7 @@ def test_call_graph_generator_decy_dependency_analysis_enabled() -> None:
     ]
     dependency_called_function_name = "functools.cache"
     dependency_called_attribute_name = "datetime.datetime.now"
-    imported_called_name = "multiprocessing.Process"
+    imported_called_constructor_name = "multiprocessing.Process"
 
     cg = CallGraphGenerator(entrypoints, package, decy=True)
     cg.analyze()
@@ -141,6 +141,6 @@ def test_call_graph_generator_decy_dependency_analysis_enabled() -> None:
 
     callees = output["fixtures.fixture_class.FixtureClass.foo"]
     assert dependency_called_attribute_name not in callees
-    assert imported_called_name not in callees
+    assert imported_called_constructor_name not in callees
     assert dependency_called_function_name in callees
     assert len(output[dependency_called_function_name]) > 0

--- a/tests/jarviscg/call_graph_generator_test.py
+++ b/tests/jarviscg/call_graph_generator_test.py
@@ -110,6 +110,7 @@ def test_call_graph_generator_dependency_analysis_disabled() -> None:
     ]
     dependency_called_function_name = "functools.cache"
     dependency_called_attribute_name = "datetime.datetime.now"
+    imported_called_name = "multiprocessing.Process"
 
     cg = CallGraphGenerator(entrypoints, package)
     cg.analyze()
@@ -118,6 +119,7 @@ def test_call_graph_generator_dependency_analysis_disabled() -> None:
 
     callees = output["fixtures.fixture_class.FixtureClass.foo"]
     assert dependency_called_attribute_name not in callees
+    assert imported_called_name in callees
     assert dependency_called_function_name in callees
     assert output[dependency_called_function_name] == []
 
@@ -130,6 +132,7 @@ def test_call_graph_generator_decy_dependency_analysis_enabled() -> None:
     ]
     dependency_called_function_name = "functools.cache"
     dependency_called_attribute_name = "datetime.datetime.now"
+    imported_called_name = "multiprocessing.Process"
 
     cg = CallGraphGenerator(entrypoints, package, decy=True)
     cg.analyze()
@@ -138,5 +141,6 @@ def test_call_graph_generator_decy_dependency_analysis_enabled() -> None:
 
     callees = output["fixtures.fixture_class.FixtureClass.foo"]
     assert dependency_called_attribute_name not in callees
+    assert imported_called_name not in callees
     assert dependency_called_function_name in callees
     assert len(output[dependency_called_function_name]) > 0

--- a/tests/jarviscg/formats/nuanced_test.py
+++ b/tests/jarviscg/formats/nuanced_test.py
@@ -15,7 +15,7 @@ def test_nuanced_formatter_formats_graph() -> None:
             "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": ["fixtures.fixture_class.FixtureClass"],
             "lineno": 1,
-            "end_lineno": 13
+            "end_lineno": 15
         },
         "fixtures.other_fixture_class": {
             "filepath": os.path.abspath("tests/fixtures/other_fixture_class.py"),
@@ -32,20 +32,20 @@ def test_nuanced_formatter_formats_graph() -> None:
         "fixtures.fixture_class.FixtureClass.__init__": {
             "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": [],
-            "lineno": 5,
-            "end_lineno": 6
+            "lineno": 6,
+            "end_lineno": 7
         },
         "fixtures.fixture_class.FixtureClass.bar": {
             "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": ["fixtures.fixture_class.FixtureClass.foo"],
-            "lineno": 12,
-            "end_lineno": 13
+            "lineno": 14,
+            "end_lineno": 15
         },
         "fixtures.fixture_class.FixtureClass.foo": {
             "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
-            "callees": ["functools.cache"],
-            "lineno": 8,
-            "end_lineno": 10
+            "callees": ["functools.cache", "multiprocessing.Process"],
+            "lineno": 9,
+            "end_lineno": 12
         }
     }
     cg = CallGraphGenerator(entrypoints, "tests")

--- a/tests/jarviscg/formats/nuanced_test.py
+++ b/tests/jarviscg/formats/nuanced_test.py
@@ -15,7 +15,7 @@ def test_nuanced_formatter_formats_graph() -> None:
             "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": ["fixtures.fixture_class.FixtureClass"],
             "lineno": 1,
-            "end_lineno": 11
+            "end_lineno": 13
         },
         "fixtures.other_fixture_class": {
             "filepath": os.path.abspath("tests/fixtures/other_fixture_class.py"),
@@ -32,20 +32,20 @@ def test_nuanced_formatter_formats_graph() -> None:
         "fixtures.fixture_class.FixtureClass.__init__": {
             "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": [],
-            "lineno": 4,
-            "end_lineno": 5
+            "lineno": 5,
+            "end_lineno": 6
         },
         "fixtures.fixture_class.FixtureClass.bar": {
             "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": ["fixtures.fixture_class.FixtureClass.foo"],
-            "lineno": 10,
-            "end_lineno": 11
+            "lineno": 12,
+            "end_lineno": 13
         },
         "fixtures.fixture_class.FixtureClass.foo": {
             "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
-            "callees": [],
-            "lineno": 7,
-            "end_lineno": 8
+            "callees": ["functools.cache"],
+            "lineno": 8,
+            "end_lineno": 10
         }
     }
     cg = CallGraphGenerator(entrypoints, "tests")


### PR DESCRIPTION
## Why?

While working on a solution for https://github.com/nuanced-dev/nuanced-operations/issues/207 I realized I didn't understand the behavior of jarviscg's `decy` option, which when `True` enables analysis of dependencies, so I'm adding two test scenarios illustrating jarviscg's handling of calls to external functions and attributes when `decy` is true/false.

## How?

- Update `FixtureClass` to import `cache` from `functools`
- Update `FixtureClass::foo` to invoke `cache`
- Update test for `formats.Nuanced` to reflect the changes to tests/fixture/fixture_class.py
- Add two new test scenarios:
  - When `decy` is `False`, we expect `FixtureClass::foo`'s callees to include `functools.cache` because it is a function but not `datetime.datetime.now` because it's an attribute. We also expect `functools.cache` to be present in the graph's nodes but, since we did not enable analysis of `functools` by setting `decy` to `True`, `functools.cache`'s callees should be empty
  - When `decy` is `True`, we expect `FixtureClass::foo`'s callees to include `functools.cache` _and_ we expect `functools.cache`'s callees to be included in the graph. We still expect `datetime.datetime.now` to be excluded from `FixtureClass::foo`'s callees.
