### PR TITLE
Include edges to imported modules' attributes when decy option is false

### DIFF
--- a/src/jarviscg/processing/extProcessor.py
+++ b/src/jarviscg/processing/extProcessor.py
@@ -211,14 +211,16 @@ class ExtProcessor(ProcessingBase):
             current_scope_node_definition = current_scope_node_definitions and current_scope_node_definitions[0]
 
             if current_scope_node_definition:
-                attr_ns = utils.join_ns(node.value.id, node.attr)
+                left = self.getYPOint(0, current_scope_node_definition.get_ns())
 
-                if not self.def_manager.get(attr_ns):
-                    left = self.getYPOint(0, current_scope_node_definition.get_ns())
-                    if left:
-                        left_defi = self.def_manager.get(left[0])
+                if left:
+                    left_defi = self.def_manager.get(left[0])
 
-                        if left_defi and left_defi.get_type() == utils.constants.EXT_DEF:
+                    if left_defi and left_defi.get_type() == utils.constants.EXT_DEF:
+                        attr_ns = utils.join_ns(left_defi.get_ns(), node.attr)
+                        attr_defi = self.def_manager.get(attr_ns)
+
+                        if not attr_defi:
                             self.def_manager.create(attr_ns, utils.constants.EXT_DEF)
 
         self.visit(node.value)

--- a/src/jarviscg/processing/extProcessor.py
+++ b/src/jarviscg/processing/extProcessor.py
@@ -219,10 +219,7 @@ class ExtProcessor(ProcessingBase):
                         left_defi = self.def_manager.get(left[0])
 
                         if left_defi and left_defi.get_type() == utils.constants.EXT_DEF:
-                            defi = self.def_manager.create(attr_ns, utils.constants.EXT_DEF)
-                            current_scope_node_definition.add_value_point(0, attr_ns)
-                            scope = self.scope_manager.get_scope(self.current_ns)
-                            scope.add_def(attr_ns, defi)
+                            self.def_manager.create(attr_ns, utils.constants.EXT_DEF)
 
         self.visit(node.value)
 

--- a/src/jarviscg/processing/extProcessor.py
+++ b/src/jarviscg/processing/extProcessor.py
@@ -1990,7 +1990,7 @@ class ExtProcessor(ProcessingBase):
         scope: ScopeItem = self.scope_manager.get_scope(scopeNs)
         scopeDefi: Definition = self.def_manager.get(scopeNs)
 
-        if not scope and scopeDefi.get_type() == utils.constants.EXT_DEF:
+        if not scope and scopeDefi and scopeDefi.get_type() == utils.constants.EXT_DEF:
             return utils.join_ns(scopeNs, field)
         defi: Definition = self.def_manager.get(scopeNs)
         if not scope:

--- a/tests/fixtures/fixture_class.py
+++ b/tests/fixtures/fixture_class.py
@@ -1,12 +1,14 @@
 from datetime import datetime
 from functools import cache
 from multiprocessing import Process
+import multiprocessing
 
 class FixtureClass():
     def __init__(self):
         self.current_time = None
 
     def foo(self) -> None:
+        multiprocessing.Pipe()
         cache(self.foo)
         Process()
         self.current_time = datetime.now()

--- a/tests/jarviscg/call_graph_generator_test.py
+++ b/tests/jarviscg/call_graph_generator_test.py
@@ -109,8 +109,14 @@ def test_call_graph_generator_dependency_analysis_disabled() -> None:
         "./tests/__init__.py",
     ]
     dependency_called_function_name = "functools.cache"
-    dependency_called_attribute_name = "datetime.datetime.now"
-    imported_called_constructor_name = "multiprocessing.Process"
+    dependency_called_attribute_name1 = "datetime.datetime.now"
+    dependency_called_attribute_name2 = "multiprocessing.Pipe"
+    imported_called_name = "multiprocessing.Process"
+    expected_callees = [
+        dependency_called_attribute_name2,
+        imported_called_name,
+        dependency_called_function_name,
+    ]
 
     cg = CallGraphGenerator(entrypoints, package)
     cg.analyze()
@@ -118,12 +124,13 @@ def test_call_graph_generator_dependency_analysis_disabled() -> None:
     output = formatter.generate()
 
     callees = output["fixtures.fixture_class.FixtureClass.foo"]
-    assert dependency_called_attribute_name not in callees
-    assert imported_called_constructor_name in callees
-    assert dependency_called_function_name in callees
+    assert dependency_called_attribute_name1 not in callees
     assert output[dependency_called_function_name] == []
+    for callee in expected_callees:
+        assert callee in callees
 
-def test_call_graph_generator_decy_dependency_analysis_enabled() -> None:
+
+def test_call_graph_generator_dependency_analysis_enabled() -> None:
     package = "tests"
     entrypoints = [
         "./tests/fixtures/fixture_class.py",
@@ -131,8 +138,9 @@ def test_call_graph_generator_decy_dependency_analysis_enabled() -> None:
         "./tests/__init__.py",
     ]
     dependency_called_function_name = "functools.cache"
-    dependency_called_attribute_name = "datetime.datetime.now"
-    imported_called_constructor_name = "multiprocessing.Process"
+    dependency_called_attribute_name1 = "datetime.datetime.now"
+    dependency_called_attribute_name2 = "multiprocessing.Pipe"
+    imported_called_name = "multiprocessing.Process"
 
     cg = CallGraphGenerator(entrypoints, package, decy=True)
     cg.analyze()
@@ -140,7 +148,8 @@ def test_call_graph_generator_decy_dependency_analysis_enabled() -> None:
     output = formatter.generate()
 
     callees = output["fixtures.fixture_class.FixtureClass.foo"]
-    assert dependency_called_attribute_name not in callees
-    assert imported_called_constructor_name not in callees
+    assert dependency_called_attribute_name1 not in callees
+    assert dependency_called_attribute_name2 not in callees
+    assert imported_called_name not in callees
     assert dependency_called_function_name in callees
     assert len(output[dependency_called_function_name]) > 0

--- a/tests/jarviscg/call_graph_generator_test.py
+++ b/tests/jarviscg/call_graph_generator_test.py
@@ -113,6 +113,7 @@ def test_call_graph_generator_dependency_analysis_disabled() -> None:
     dependency_called_attribute_name2 = "multiprocessing.Pipe"
     imported_called_name = "multiprocessing.Process"
     expected_callees = [
+        dependency_called_attribute_name1,
         dependency_called_attribute_name2,
         imported_called_name,
         dependency_called_function_name,
@@ -124,7 +125,6 @@ def test_call_graph_generator_dependency_analysis_disabled() -> None:
     output = formatter.generate()
 
     callees = output["fixtures.fixture_class.FixtureClass.foo"]
-    assert dependency_called_attribute_name1 not in callees
     assert output[dependency_called_function_name] == []
     for callee in expected_callees:
         assert callee in callees

--- a/tests/jarviscg/formats/nuanced_test.py
+++ b/tests/jarviscg/formats/nuanced_test.py
@@ -15,7 +15,7 @@ def test_nuanced_formatter_formats_graph() -> None:
             "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": ["fixtures.fixture_class.FixtureClass"],
             "lineno": 1,
-            "end_lineno": 15
+            "end_lineno": 17
         },
         "fixtures.other_fixture_class": {
             "filepath": os.path.abspath("tests/fixtures/other_fixture_class.py"),
@@ -32,20 +32,20 @@ def test_nuanced_formatter_formats_graph() -> None:
         "fixtures.fixture_class.FixtureClass.__init__": {
             "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": [],
-            "lineno": 6,
-            "end_lineno": 7
+            "lineno": 7,
+            "end_lineno": 8
         },
         "fixtures.fixture_class.FixtureClass.bar": {
             "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
             "callees": ["fixtures.fixture_class.FixtureClass.foo"],
-            "lineno": 14,
-            "end_lineno": 15
+            "lineno": 16,
+            "end_lineno": 17
         },
         "fixtures.fixture_class.FixtureClass.foo": {
             "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
-            "callees": ["functools.cache", "multiprocessing.Process"],
-            "lineno": 9,
-            "end_lineno": 12
+            "callees": ["functools.cache", "multiprocessing.Process", "multiprocessing.Pipe"],
+            "lineno": 10,
+            "end_lineno": 14
         }
     }
     cg = CallGraphGenerator(entrypoints, "tests")

--- a/tests/jarviscg/formats/nuanced_test.py
+++ b/tests/jarviscg/formats/nuanced_test.py
@@ -43,7 +43,12 @@ def test_nuanced_formatter_formats_graph() -> None:
         },
         "fixtures.fixture_class.FixtureClass.foo": {
             "filepath": os.path.abspath("tests/fixtures/fixture_class.py"),
-            "callees": ["functools.cache", "multiprocessing.Process", "multiprocessing.Pipe"],
+            "callees": [
+                "functools.cache",
+                "multiprocessing.Process",
+                "multiprocessing.Pipe",
+                "datetime.datetime.now",
+            ],
             "lineno": 10,
             "end_lineno": 14
         }


### PR DESCRIPTION
## Why?

We noticed that edges to attributes of imported modules aren't included in jarviscg's call graphs. We want the call graphs generated by jarviscg to be more complete. Ref: https://github.com/nuanced-dev/nuanced-operations/issues/207

## How?

- Add behavior to jarviscg's algorithm for walking and parsing file ASTs by extending `ExtProcessor` with a new method, `visit_Attribute`. This method is executed when `ExtProcessor`, which inherits from [`ast.NodeVisitor`](https://docs.python.org/3/library/ast.html#ast.NodeVisitor), visits `ast.Attribute` nodes.
  - If dependency analysis via the `decy` option is _not_ enabled and the `ast.Attribute` node's `value` is an `ast.Name` node, proceed with analysis:
     - Query for definition in the current scope using `ExtProcessor::decode_node`. Example: for `multiprocessing.Pipe()`, with the current scope of `fixtures.fixture_class`, query for `multiprocessing` definition in current scope, which would be `fixtures.fixture_class.multiprocessing` if found. Proceed if it exists.
     - Then check for a definition in the current scope for the `node.attr`. Example: for `multiprocessing.Pipe()`, query for `multiprocessing.Pipe` definition. Proceed if it doesn't exist (i.e. hasn't already been created).
     - Query for "left" definitions for definition found in first step. Example: for `fixtures.fixture_class.multiprocessing`, the "left" definition would be `multiprocessing`, which would have been created when `visit_Import` was executed with the AST node representing the statement `import multiprocessing` in the file fixtures/fixture_class.py. [code ref](https://github.com/nuanced-dev/jarviscg/blob/main/src/jarviscg/processing/extProcessor.py#L383-L422)
     - If there is a "left" definition and it is of type `utils.constants.EXT_DEF`, indicating that it represents an external definition, create a new definition for the attribute of the imported module of type `utils.constants.EXT_DEF`. Example: the definition name for `multiprocessing.Pipe()` is `multiprocessing.Pipe`. Using the type `utils.constants.EXT_DEF` for this case is consistent with jarviscg's handling of explicitly imported functions, e.g. given a file with the statement `from multiprocessing import Process` and the call `Process()`, jarviscg will create a definition for `multiprocessing.Process` with the type `utils.constants.EXT_DEF`
- Fix what appears to be a bug on L1972, now L1994, of `ExtProcessor::find_field`: instead of checking `scopeDefi == utils.constants.EXT_DEF`, which will always return `False` because `utils.constants.EXT_DEF` is a string and `scopeDefi` is a `Definition`, check `scopeDefi.get_type() == utils.constants.EXT_DEF`. Fixing this bug allows the processing of `ast.Attribute` nodes originating from `visit_Call` to correctly identify attributes that are fields of imported modules. [code ref](https://github.com/nuanced-dev/jarviscg/blob/main/src/jarviscg/processing/extProcessor.py#L1106)

## Considerations

So many ...

- The main consideration is: why doesn't jarviscg already process `ast.Attribute` nodes in order to map calls to functions that are exposed as attributes of imported modules? I reviewed the codebase thoroughly for clues and spent hours reviewing the output of debugging statements, but I don't have a clear answer. I did see a comment in `BaseProcessor` that gave me pause: ["hack: external attributes can lead to infinite loops"](https://github.com/nuanced-dev/jarviscg/blob/main/src/jarviscg/processing/base.py#L380-L381). Something for me to consider and keep an eye out for as I'm doing QA.
- Enabling dependency analysis with the `decy` option already has some issues, which are illustrated in call_graph_generator_test.py, hence my decision to reduce scope and complexity by only mapping edges to attributes of imported modules when `decy` is `False`. nuanced and nuanced-python invoke jarviscg without enabling dependency analysis so this will have no impact on nuanced users.