### PR TITLE
Formatter optionally includes relpath in fully qualified names

### DIFF
--- a/src/jarviscg/formats/nuanced.py
+++ b/src/jarviscg/formats/nuanced.py
@@ -1,8 +1,10 @@
 import os
-from .base import BaseFormatter
+from jarviscg.formats.base import BaseFormatter
+from jarviscg import utils
 
 class Nuanced(BaseFormatter):
-    def __init__(self, cg_generator):
+    def __init__(self, cg_generator, *, relpath=None):
+        self.relpath = relpath
         self.cg_generator = cg_generator
         self.internal_mods = self.cg_generator.output_internal_mods() or {}
         self.edges = self.cg_generator.output_edges() or []
@@ -23,4 +25,24 @@ class Nuanced(BaseFormatter):
             if src in output:
                 output[src]["callees"].append(dst)
 
-        return output
+        if self.relpath:
+            dir_parts = self.relpath.split("/")
+            last_dir = dir_parts[-1]
+            relpath_prefix = ".".join(dir_parts[:-1])
+
+            return {
+                self._transform_name(name, relpath_prefix, last_dir): {
+                    **attrs,
+                    "callees": [self._transform_name(callee, relpath_prefix, last_dir) for callee in attrs["callees"]]
+                }
+                for name, attrs in output.items()
+                if name.split(".")[0] == last_dir
+            }
+        else:
+            return output
+
+    def _transform_name(self, name, relpath_prefix, last_dir):
+        if name.split(".")[0] == last_dir:
+            return utils.join_ns(relpath_prefix, name)
+        else:
+            return name


### PR DESCRIPTION
## Why?

Generating a call graph for a package does not produce a graph that includes the relative path from the directory where the analysis process was executed to the package under analysis.

For example, in order to produce a graph for the `nuanced` package with the greatest degree of completeness, we execute `jarviscg $(find src/nuanced -name "*.py" -type f) --package src` from the `nuanced` directory in our local git repository. However, this produces a graph with node names starting with `"nuanced.` instead of `"nuanced.src.nuanced` or `"src.nuanced`.

We would like for the module, class or function represented by a given node name in the Nuanced graph to be importable from the directory in which the graph was generated (assuming the code is available). In order to make this possible, this PR adds an option to the `formats.Nuanced` formatter to prepend node names with relative path information.

## How?

- Add `relpath` keyword argument with default value `None` to `formats.Nuanced`
- If `relpath` is present, transform call graph by prepending relative path parts to names of nodes representing modules, classes or functions defined within the scope of the relative path

ref: https://github.com/nuanced-dev/nuanced-operations/issues/239