### PR TITLE
Bump version to 0.1.0rc6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0rc6] - 2025-06-17
+
+### Added
+
+- Update `formats.Nuanced` to optionally prepend `scope_prefix` to graph nodes and callees defined within the scopes encoded in `scope_prefix` (https://github.com/nuanced-dev/jarviscg/pull/37)
+
+### Fixed
+
+### Changed
+
+### Removed
+
 ## [0.1.0rc5] - 2025-06-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jarviscg"
-version = "0.1.0rc5"
+version = "0.1.0rc6"
 description = "Call graph generator for Python forked from pythonJaRvis/pythonJaRvis.github.io"
 readme = "README.md"
 authors = [

--- a/src/jarviscg/__init__.py
+++ b/src/jarviscg/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.0rc5"
+__version__ = "0.1.0rc6"

--- a/uv.lock
+++ b/uv.lock
@@ -47,7 +47,7 @@ wheels = [
 
 [[package]]
 name = "jarviscg"
-version = "0.1.0rc5"
+version = "0.1.0rc6"
 source = { editable = "." }
 dependencies = [
     { name = "deepdiff" },


### PR DESCRIPTION
Pre-review checklist:
- [x] The version number in `pyproject.toml` has been updated
- [x] `__version__` in `src/jarviscg/__init__.py` has been updated
- [x] `uv.lock` has been updated by running `uv sync`
- [x] `CHANGELOG.md` has been updated

Post-merge checklist:
- [ ] Create GitHub Release
- [ ] Publish package to TestPyPI
- [ ] Publish package to PyPI
- [ ] Verify installation
  - [ ] `pip install jarviscg`
  - [ ] `uv tool install jarviscg`

References:
 - [nuanced Release Process](https://docs.nuanced.dev/versioning#release-process)